### PR TITLE
Fix: now only sends basic participant data to the update, create a…

### DIFF
--- a/application/CohortManager/src/Functions/CaasIntegration/processCaasFile/Program.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/processCaasFile/Program.cs
@@ -10,6 +10,7 @@ var host = new HostBuilder()
         services.AddSingleton<ICallFunction, CallFunction>();
         services.AddSingleton<ICreateResponse, CreateResponse>();
         services.AddSingleton<ICheckDemographic, CheckDemographic>();
+        services.AddSingleton<ICreateBasicParticipantData, CreateBasicParticipantData>();
     })
     .Build();
 

--- a/application/CohortManager/src/Functions/CaasIntegration/processCaasFile/processCaasFile.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/processCaasFile/processCaasFile.cs
@@ -59,7 +59,7 @@ namespace processCaasFile
                         add++;
                         try
                         {
-                            var json = JsonSerializer.Serialize(_createBasicParticipantData.basicParticipantData(p));
+                            var json = JsonSerializer.Serialize(_createBasicParticipantData.BasicParticipantData(p));
                             var addresp = await _callFunction.SendPost(Environment.GetEnvironmentVariable("PMSAddParticipant"), json);
                             _logger.LogInformation("Called add participant");
                         }
@@ -72,7 +72,7 @@ namespace processCaasFile
                         upd++;
                         try
                         {
-                            var json = JsonSerializer.Serialize(_createBasicParticipantData.basicParticipantData(p));
+                            var json = JsonSerializer.Serialize(_createBasicParticipantData.BasicParticipantData(p));
                             var addresp = await _callFunction.SendPost(Environment.GetEnvironmentVariable("PMSUpdateParticipant"), json);
                             _logger.LogInformation("Called update participant");
 
@@ -86,7 +86,7 @@ namespace processCaasFile
                         del++;
                         try
                         {
-                            var json = JsonSerializer.Serialize(_createBasicParticipantData.basicParticipantData(p));
+                            var json = JsonSerializer.Serialize(_createBasicParticipantData.BasicParticipantData(p));
                             var addresp = await _callFunction.SendPost(Environment.GetEnvironmentVariable("PMSRemoveParticipant"), json);
                             _logger.LogInformation("Called remove participant");
                         }

--- a/application/CohortManager/src/Functions/CaasIntegration/processCaasFile/processCaasFile.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/processCaasFile/processCaasFile.cs
@@ -15,13 +15,15 @@ namespace processCaasFile
         private readonly ICallFunction _callFunction;
         private readonly ICreateResponse _createResponse;
         private readonly ICheckDemographic _checkDemographic;
+        private readonly ICreateBasicParticipantData _createBasicParticipantData;
 
-        public ProcessCaasFileFunction(ILogger<ProcessCaasFileFunction> logger, ICallFunction callFunction, ICreateResponse createResponse, ICheckDemographic checkDemographic)
+        public ProcessCaasFileFunction(ILogger<ProcessCaasFileFunction> logger, ICallFunction callFunction, ICreateResponse createResponse, ICheckDemographic checkDemographic, ICreateBasicParticipantData createBasicParticipantData)
         {
             _logger = logger;
             _callFunction = callFunction;
             _createResponse = createResponse;
             _checkDemographic = checkDemographic;
+            _createBasicParticipantData = createBasicParticipantData;
         }
 
         [Function("processCaasFile")]
@@ -57,7 +59,7 @@ namespace processCaasFile
                         add++;
                         try
                         {
-                            var json = JsonSerializer.Serialize(p);
+                            var json = JsonSerializer.Serialize(_createBasicParticipantData.basicParticipantData(p));
                             var addresp = await _callFunction.SendPost(Environment.GetEnvironmentVariable("PMSAddParticipant"), json);
                             _logger.LogInformation("Called add participant");
                         }
@@ -70,7 +72,7 @@ namespace processCaasFile
                         upd++;
                         try
                         {
-                            var json = JsonSerializer.Serialize(p);
+                            var json = JsonSerializer.Serialize(_createBasicParticipantData.basicParticipantData(p));
                             var addresp = await _callFunction.SendPost(Environment.GetEnvironmentVariable("PMSUpdateParticipant"), json);
                             _logger.LogInformation("Called update participant");
 
@@ -84,7 +86,7 @@ namespace processCaasFile
                         del++;
                         try
                         {
-                            var json = JsonSerializer.Serialize(p);
+                            var json = JsonSerializer.Serialize(_createBasicParticipantData.basicParticipantData(p));
                             var addresp = await _callFunction.SendPost(Environment.GetEnvironmentVariable("PMSRemoveParticipant"), json);
                             _logger.LogInformation("Called remove participant");
                         }

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/RemoveParticipant/RemoveParticipant.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/RemoveParticipant/RemoveParticipant.cs
@@ -43,16 +43,16 @@ namespace RemoveParticipant
                     postdata = reader.ReadToEnd();
                 }
 
-                var participant = JsonSerializer.Deserialize<Participant>(postdata);
+                var basicParticipantData = JsonSerializer.Deserialize<BasicParticipantData>(postdata);
 
-                var demographicData = await _checkDemographic.GetDemographicAsync(participant.NHSId, Environment.GetEnvironmentVariable("DemographicURIGet"));
+                var demographicData = await _checkDemographic.GetDemographicAsync(basicParticipantData.NHSId, Environment.GetEnvironmentVariable("DemographicURIGet"));
                 if (demographicData == null)
                 {
                     _logger.LogInformation("demographic function failed");
                     return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
                 }
 
-                participant = _createParticipant.CreateResponseParticipantModel(participant, demographicData);
+                var participant = _createParticipant.CreateResponseParticipantModel(basicParticipantData, demographicData);
                 var json = JsonSerializer.Serialize(participant);
 
                 createResponse = await _callFunction.SendPost(Environment.GetEnvironmentVariable("markParticipantAsIneligible"), json);

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/addParticipant/addParticipant.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/addParticipant/addParticipant.cs
@@ -37,21 +37,22 @@ namespace addParticipant
 
             // convert body to json and then deserialize to object
             string postdata = "";
+            Participant participant = new Participant();
             using (StreamReader reader = new StreamReader(req.Body, Encoding.UTF8))
             {
                 postdata = reader.ReadToEnd();
             }
-            var participant = JsonSerializer.Deserialize<Participant>(postdata);
+            var basicParticipant = JsonSerializer.Deserialize<BasicParticipantData>(postdata);
 
             try
             {
-                var demographicData = await _getDemographicData.GetDemographicAsync(participant.NHSId, Environment.GetEnvironmentVariable("DemographicURIGet"));
+                var demographicData = await _getDemographicData.GetDemographicAsync(basicParticipant.NHSId, Environment.GetEnvironmentVariable("DemographicURIGet"));
                 if (demographicData == null)
                 {
                     _logger.LogInformation("demographic function failed");
                     return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
                 }
-                participant = _createParticipant.CreateResponseParticipantModel(participant, demographicData);
+                participant = _createParticipant.CreateResponseParticipantModel(basicParticipant, demographicData);
 
                 var json = JsonSerializer.Serialize(participant);
 

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/updateParticipant/updateParticipant.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/updateParticipant/updateParticipant.cs
@@ -40,25 +40,25 @@ public class UpdateParticipantFunction
         {
             postdata = reader.ReadToEnd();
         }
-        var participant = JsonSerializer.Deserialize<Participant>(postdata);
-
-        if (!await ValidateData(participant))
-        {
-            _logger.LogInformation("The participant has not been updated due to a bad request.");
-            return _createResponse.CreateHttpResponse(HttpStatusCode.BadRequest, req);
-        }
+        var basicParticipantData = JsonSerializer.Deserialize<BasicParticipantData>(postdata);
 
         try
         {
-            var demographicData = await _checkDemographic.GetDemographicAsync(participant.NHSId, Environment.GetEnvironmentVariable("DemographicURIGet"));
+            var demographicData = await _checkDemographic.GetDemographicAsync(basicParticipantData.NHSId, Environment.GetEnvironmentVariable("DemographicURIGet"));
             if (demographicData == null)
             {
                 _logger.LogInformation("demographic function failed");
                 return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
             }
-
-            participant = _createParticipant.CreateResponseParticipantModel(participant, demographicData);
+            var participant = _createParticipant.CreateResponseParticipantModel(basicParticipantData, demographicData);
             var json = JsonSerializer.Serialize(participant);
+
+            if (!await ValidateData(participant))
+            {
+                _logger.LogInformation("The participant has not been updated due to a bad request.");
+                return _createResponse.CreateHttpResponse(HttpStatusCode.BadRequest, req);
+            }
+
             createResponse = await _callFunction.SendPost(Environment.GetEnvironmentVariable("UpdateParticipant"), json);
 
             if (createResponse.StatusCode == HttpStatusCode.OK)
@@ -74,7 +74,6 @@ public class UpdateParticipantFunction
         }
 
         _logger.LogInformation("The participant has not been updated due to a bad request.");
-
         return _createResponse.CreateHttpResponse(HttpStatusCode.BadRequest, req);
     }
 

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/updateParticipant/updateParticipant.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/updateParticipant/updateParticipant.cs
@@ -48,7 +48,7 @@ public class UpdateParticipantFunction
             if (demographicData == null)
             {
                 _logger.LogInformation("demographic function failed");
-                return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
+                return _createResponse.CreateHttpResponse(HttpStatusCode.BadRequest, req);
             }
             var participant = _createParticipant.CreateResponseParticipantModel(basicParticipantData, demographicData);
             var json = JsonSerializer.Serialize(participant);

--- a/application/CohortManager/src/Functions/Shared/Common/CreateBasicParticipantData.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/CreateBasicParticipantData.cs
@@ -1,0 +1,33 @@
+using Model;
+
+namespace Common;
+
+public class CreateBasicParticipantData : ICreateBasicParticipantData
+{
+    public BasicParticipantData basicParticipantData(Participant participant)
+    {
+        return new BasicParticipantData
+        {
+            RecordType = participant.RecordType,
+            ChangeTimeStamp = participant.ChangeTimeStamp,
+            SerialChangeNumber = participant.SerialChangeNumber,
+            NHSId = participant.NHSId,
+            SupersededByNhsNumber = participant.SupersededByNhsNumber,
+            PrimaryCareProviderEffectiveFrom = participant.PrimaryCareProviderEffectiveFrom,
+            CurrentPostingEffectiveFrom = participant.CurrentPostingEffectiveFrom,
+            PreviousPosting = participant.PreviousPosting,
+            PreviousPostingEffectiveFrom = participant.PreviousPostingEffectiveFrom,
+            OtherGivenNames = participant.OtherGivenNames,
+            PreviousSurname = participant.PreviousSurname,
+            AddressLine5 = participant.AddressLine5,
+            PafKey = participant.PafKey,
+            UsualAddressEffectiveFromDate = participant.UsualAddressEffectiveFromDate,
+            TelephoneNumberEffectiveFromDate = participant.TelephoneNumberEffectiveFromDate,
+            MobileNumber = participant.MobileNumber,
+            MobileNumberEffectiveFromDate = participant.MobileNumberEffectiveFromDate,
+            EmailAddressEffectiveFromDate = participant.EmailAddressEffectiveFromDate,
+            InvalidFlag = participant.InvalidFlag,
+            ChangeReasonCode = participant.ChangeReasonCode
+        };
+    }
+}

--- a/application/CohortManager/src/Functions/Shared/Common/CreateBasicParticipantData.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/CreateBasicParticipantData.cs
@@ -4,7 +4,7 @@ namespace Common;
 
 public class CreateBasicParticipantData : ICreateBasicParticipantData
 {
-    public BasicParticipantData basicParticipantData(Participant participant)
+    public BasicParticipantData BasicParticipantData(Participant participant)
     {
         return new BasicParticipantData
         {

--- a/application/CohortManager/src/Functions/Shared/Common/CreateParticipant.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/CreateParticipant.cs
@@ -5,7 +5,7 @@ namespace Common;
 
 public class CreateParticipant : ICreateParticipant
 {
-    public Participant CreateResponseParticipantModel(Participant participant, Demographic demographic)
+    public Participant CreateResponseParticipantModel(BasicParticipantData participant, Demographic demographic)
     {
         return new Participant
         {

--- a/application/CohortManager/src/Functions/Shared/Common/Interfaces/ICreateBasicParticipantData.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Interfaces/ICreateBasicParticipantData.cs
@@ -1,0 +1,8 @@
+using Model;
+
+namespace Common;
+
+public interface ICreateBasicParticipantData
+{
+    public BasicParticipantData basicParticipantData(Participant participant);
+}

--- a/application/CohortManager/src/Functions/Shared/Common/Interfaces/ICreateBasicParticipantData.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Interfaces/ICreateBasicParticipantData.cs
@@ -4,5 +4,5 @@ namespace Common;
 
 public interface ICreateBasicParticipantData
 {
-    public BasicParticipantData basicParticipantData(Participant participant);
+    public BasicParticipantData BasicParticipantData(Participant participant);
 }

--- a/application/CohortManager/src/Functions/Shared/Common/Interfaces/ICreateParticipant.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Interfaces/ICreateParticipant.cs
@@ -4,5 +4,5 @@ namespace Common;
 
 public interface ICreateParticipant
 {
-    public Participant CreateResponseParticipantModel(Participant participant, Demographic demographic);
+    public Participant CreateResponseParticipantModel(BasicParticipantData participant, Demographic demographic);
 }

--- a/application/CohortManager/src/Functions/Shared/Model/BasicParticipantData.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/BasicParticipantData.cs
@@ -1,0 +1,25 @@
+namespace Model;
+
+public class BasicParticipantData
+{
+    public string? RecordType { get; set; }
+    public string? ChangeTimeStamp { get; set; }
+    public string? SerialChangeNumber { get; set; }
+    public string? NHSId { get; set; }
+    public string? SupersededByNhsNumber { get; set; }
+    public string? PrimaryCareProviderEffectiveFrom { get; set; }
+    public string? CurrentPostingEffectiveFrom { get; set; }
+    public string? PreviousPosting { get; set; }
+    public string? PreviousPostingEffectiveFrom { get; set; }
+    public string? OtherGivenNames { get; set; }
+    public string? PreviousSurname { get; set; }
+    public string? AddressLine5 { get; set; }
+    public string? PafKey { get; set; }
+    public string? UsualAddressEffectiveFromDate { get; set; }
+    public string? TelephoneNumberEffectiveFromDate { get; set; }
+    public string? MobileNumber { get; set; }
+    public string? MobileNumberEffectiveFromDate { get; set; }
+    public string? EmailAddressEffectiveFromDate { get; set; }
+    public string? InvalidFlag { get; set; }
+    public string? ChangeReasonCode { get; set; }
+}

--- a/tests/CaasIntegrationTests/processCaasFileTest/processCaasFileTests.cs
+++ b/tests/CaasIntegrationTests/processCaasFileTest/processCaasFileTests.cs
@@ -24,7 +24,7 @@ public class processCaasFileTests
     private readonly Mock<FunctionContext> context = new();
     private readonly Mock<HttpRequestData> request;
     private readonly Mock<ICreateResponse> createResponse = new();
-
+    private readonly Mock<ICreateBasicParticipantData> _createBasicParticipantData = new();
     private readonly Mock<ICheckDemographic> checkDemographic = new();
 
     public processCaasFileTests()
@@ -55,7 +55,7 @@ public class processCaasFileTests
         var json = JsonSerializer.Serialize(cohort);
 
         setupRequest(json);
-        var sut = new ProcessCaasFileFunction(loggerMock.Object, callFunctionMock.Object, createResponse.Object, checkDemographic.Object);
+        var sut = new ProcessCaasFileFunction(loggerMock.Object, callFunctionMock.Object, createResponse.Object, checkDemographic.Object, _createBasicParticipantData.Object);
 
         //Act
         var result = await sut.Run(request.Object);
@@ -79,7 +79,7 @@ public class processCaasFileTests
                 }
         };
         var json = JsonSerializer.Serialize(cohort);
-        var sut = new ProcessCaasFileFunction(loggerMock.Object, callFunctionMock.Object, createResponse.Object, checkDemographic.Object);
+        var sut = new ProcessCaasFileFunction(loggerMock.Object, callFunctionMock.Object, createResponse.Object, checkDemographic.Object, _createBasicParticipantData.Object);
 
         setupRequest(json);
 
@@ -111,7 +111,7 @@ public class processCaasFileTests
         callFunctionMock.Setup(call => call.SendPost(It.Is<string>(s => s.Contains("PMSUpdateParticipant")), It.IsAny<string>()))
             .ThrowsAsync(exception);
 
-        var sut = new ProcessCaasFileFunction(loggerMock.Object, callFunctionMock.Object, createResponse.Object, checkDemographic.Object);
+        var sut = new ProcessCaasFileFunction(loggerMock.Object, callFunctionMock.Object, createResponse.Object, checkDemographic.Object, _createBasicParticipantData.Object);
 
         // Act
         await sut.Run(request.Object);
@@ -140,7 +140,7 @@ public class processCaasFileTests
                 }
         };
         var json = JsonSerializer.Serialize(cohort);
-        var sut = new ProcessCaasFileFunction(loggerMock.Object, callFunctionMock.Object, createResponse.Object, checkDemographic.Object);
+        var sut = new ProcessCaasFileFunction(loggerMock.Object, callFunctionMock.Object, createResponse.Object, checkDemographic.Object, _createBasicParticipantData.Object);
 
         setupRequest(json);
 
@@ -172,7 +172,7 @@ public class processCaasFileTests
         callFunctionMock.Setup(call => call.SendPost(It.Is<string>(s => s.Contains("PMSRemoveParticipant")), It.IsAny<string>()))
             .ThrowsAsync(exception);
 
-        var sut = new ProcessCaasFileFunction(loggerMock.Object, callFunctionMock.Object, createResponse.Object, checkDemographic.Object);
+        var sut = new ProcessCaasFileFunction(loggerMock.Object, callFunctionMock.Object, createResponse.Object, checkDemographic.Object, _createBasicParticipantData.Object);
 
         // Act
         await sut.Run(request.Object);

--- a/tests/ParticipantManagementServicesTests/updateParticipantTests/updateParticipantTests.cs
+++ b/tests/ParticipantManagementServicesTests/updateParticipantTests/updateParticipantTests.cs
@@ -69,10 +69,12 @@ public class UpdateParticipantTests
         _callFunction.Setup(call => call.SendPost(It.Is<string>(s => s.Contains("StaticValidationURL")), It.IsAny<string>()))
                         .Returns(Task.FromResult<HttpWebResponse>(_webResponse.Object));
 
-        // Act
+        _checkDemographic.Setup(call => call.GetDemographicAsync(It.IsAny<string>(), It.Is<string>(s => s.Contains("DemographicURIGet"))))
+                        .Returns(Task.FromResult<Demographic>(new Demographic()));
+        //Act
         var result = await sut.Run(_request.Object);
 
-        // Assert
+        //Assert
         _createResponse.Verify(x => x.CreateHttpResponse(HttpStatusCode.BadRequest, _request.Object, ""), Times.Once());
         _callFunction.Verify(call => call.SendPost(It.Is<string>(s => s == "UpdateParticipant"), It.IsAny<string>()), Times.Never());
 
@@ -171,7 +173,6 @@ public class UpdateParticipantTests
         _callFunction.Setup(call => call.SendPost(It.Is<string>(s => s == "StaticValidationURL"), json))
             .Returns(Task.FromResult<HttpWebResponse>(_validationWebResponse.Object));
 
-
         _updateParticipantWebResponse.Setup(x => x.StatusCode).Throws(new Exception("an error occurred"));
         _callFunction.Setup(call => call.SendPost(It.Is<string>(s => s.Contains("UpdateParticipant")), It.IsAny<string>()))
                         .Returns(Task.FromResult<HttpWebResponse>(_updateParticipantWebResponse.Object));
@@ -186,6 +187,9 @@ public class UpdateParticipantTests
             response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
             return response;
         });
+
+        createParticipant.Setup(x => x.CreateResponseParticipantModel(It.IsAny<BasicParticipantData>(), It.IsAny<Demographic>()))
+        .Returns(_participant);
 
         var sut = new UpdateParticipantFunction(_logger.Object, _createResponse.Object, _callFunction.Object, _checkDemographic.Object, createParticipant.Object);
 

--- a/tests/ParticipantManagementServicesTests/updateParticipantTests/updateParticipantTests.cs
+++ b/tests/ParticipantManagementServicesTests/updateParticipantTests/updateParticipantTests.cs
@@ -26,7 +26,7 @@ public class UpdateParticipantTests
 
     Mock<ICheckDemographic> _checkDemographic = new();
 
-    Mock<ICreateParticipant> createParticipant = new();
+    Mock<ICreateParticipant> _createParticipant = new();
 
     Mock<HttpWebResponse> _validationWebResponse = new();
 
@@ -63,7 +63,7 @@ public class UpdateParticipantTests
         // Arrange
         var json = JsonSerializer.Serialize(_participant);
         setupRequest(json);
-        var sut = new UpdateParticipantFunction(_logger.Object, _createResponse.Object, _callFunction.Object, _checkDemographic.Object, createParticipant.Object);
+        var sut = new UpdateParticipantFunction(_logger.Object, _createResponse.Object, _callFunction.Object, _checkDemographic.Object, _createParticipant.Object);
 
         _webResponse.Setup(x => x.StatusCode).Returns(HttpStatusCode.BadRequest);
         _callFunction.Setup(call => call.SendPost(It.Is<string>(s => s.Contains("StaticValidationURL")), It.IsAny<string>()))
@@ -109,7 +109,7 @@ public class UpdateParticipantTests
 
         setupRequest(json);
 
-        var sut = new UpdateParticipantFunction(_logger.Object, _createResponse.Object, _callFunction.Object, _checkDemographic.Object, createParticipant.Object);
+        var sut = new UpdateParticipantFunction(_logger.Object, _createResponse.Object, _callFunction.Object, _checkDemographic.Object, _createParticipant.Object);
 
         // Act
         var result = await sut.Run(_request.Object);
@@ -153,7 +153,7 @@ public class UpdateParticipantTests
         });
 
 
-        var sut = new UpdateParticipantFunction(_logger.Object, _createResponse.Object, _callFunction.Object, _checkDemographic.Object, createParticipant.Object);
+        var sut = new UpdateParticipantFunction(_logger.Object, _createResponse.Object, _callFunction.Object, _checkDemographic.Object, _createParticipant.Object);
 
         // Act
         var result = await sut.Run(_request.Object);
@@ -188,10 +188,10 @@ public class UpdateParticipantTests
             return response;
         });
 
-        createParticipant.Setup(x => x.CreateResponseParticipantModel(It.IsAny<BasicParticipantData>(), It.IsAny<Demographic>()))
+        _createParticipant.Setup(x => x.CreateResponseParticipantModel(It.IsAny<BasicParticipantData>(), It.IsAny<Demographic>()))
         .Returns(_participant);
 
-        var sut = new UpdateParticipantFunction(_logger.Object, _createResponse.Object, _callFunction.Object, _checkDemographic.Object, createParticipant.Object);
+        var sut = new UpdateParticipantFunction(_logger.Object, _createResponse.Object, _callFunction.Object, _checkDemographic.Object, _createParticipant.Object);
 
         // Act
         var result = await sut.Run(_request.Object);


### PR DESCRIPTION
…nd remove. Adding new object 'BasicParticpantData'. updating create particpant data to use new object

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

this pull request aims to only send the very basic participant data to the add, remove and create functions

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
