### PR TITLE
feat: Process unknown participant record types

### DIFF
--- a/application/CohortManager/src/Functions/CaasIntegration/processCaasFile/processCaasFile.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/processCaasFile/processCaasFile.cs
@@ -1,4 +1,4 @@
-namespace processCaasFile;
+namespace NHS.CohortManager.CaasIntegrationService;
 
 using System.Net;
 using System.Text;
@@ -36,40 +36,38 @@ public class ProcessCaasFileFunction
         }
         Cohort input = JsonSerializer.Deserialize<Cohort>(postData);
 
-        _logger.LogInformation("Records received: \n" + input.Participants.Count);
-        _logger.LogInformation($"Records received {input.Participants.Count}");
+        _logger.LogInformation("Records received: {Count}", input.Participants.Count);
 
         int add = 0, upd = 0, del = 0, err = 0, row = 0;
 
-        foreach (var p in input.Participants)
+        foreach (var participant in input.Participants)
         {
             row++;
-            var recordTypeTrimmed = p.RecordType.Trim();
-            var demographicDataInserted = await _checkDemographic.PostDemographicDataAsync(p, Environment.GetEnvironmentVariable("DemographicURI"));
+            var demographicDataInserted = await _checkDemographic.PostDemographicDataAsync(participant, Environment.GetEnvironmentVariable("DemographicURI"));
             if (demographicDataInserted == false)
             {
-                _logger.LogError("demographic function failed");
+                _logger.LogError("Demographic function failed");
             }
 
             var basicParticipantCsvRecord = new BasicParticipantCsvRecord
             {
-                Participant = _createBasicParticipantData.BasicParticipantData(p),
+                Participant = _createBasicParticipantData.BasicParticipantData(participant),
                 FileName = input.FileName
             };
 
-            switch (recordTypeTrimmed)
+            switch (participant.RecordType?.Trim())
             {
                 case Actions.New:
                     add++;
                     try
                     {
                         var json = JsonSerializer.Serialize(basicParticipantCsvRecord);
-                        var addresp = await _callFunction.SendPost(Environment.GetEnvironmentVariable("PMSAddParticipant"), json);
+                        await _callFunction.SendPost(Environment.GetEnvironmentVariable("PMSAddParticipant"), json);
                         _logger.LogInformation("Called add participant");
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError($"Unable to call function.\nMessage: {ex.Message}\nStack Trace: {ex.StackTrace}");
+                        _logger.LogError("Add participant function failed.\nMessage: {Message}\nStack Trace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                     break;
                 case Actions.Amended:
@@ -77,12 +75,12 @@ public class ProcessCaasFileFunction
                     try
                     {
                         var json = JsonSerializer.Serialize(basicParticipantCsvRecord);
-                        var addresp = await _callFunction.SendPost(Environment.GetEnvironmentVariable("PMSUpdateParticipant"), json);
+                        await _callFunction.SendPost(Environment.GetEnvironmentVariable("PMSUpdateParticipant"), json);
                         _logger.LogInformation("Called update participant");
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogInformation($"Unable to call function.\nMessage: {ex.Message}\nStack Trace: {ex.StackTrace}");
+                        _logger.LogError("Update participant function failed.\nMessage: {Message}\nStack Trace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                     break;
                 case Actions.Removed:
@@ -90,21 +88,31 @@ public class ProcessCaasFileFunction
                     try
                     {
                         var json = JsonSerializer.Serialize(basicParticipantCsvRecord);
-                        var addresp = await _callFunction.SendPost(Environment.GetEnvironmentVariable("PMSRemoveParticipant"), json);
+                        await _callFunction.SendPost(Environment.GetEnvironmentVariable("PMSRemoveParticipant"), json);
                         _logger.LogInformation("Called remove participant");
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogInformation($"Unable to call function.\nMessage: {ex.Message}\nStack Trace: {ex.StackTrace}");
+                        _logger.LogError("Remove participant function failed.\nMessage: {Message}\nStack Trace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                     break;
                 default:
                     err++;
+                    try
+                    {
+                        var json = JsonSerializer.Serialize(participant);
+                        await _callFunction.SendPost(Environment.GetEnvironmentVariable("StaticValidationURL"), json);
+                        _logger.LogInformation("Called static validation");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError("Static validation function failed.\nMessage: {Message}\nStack Trace: {StackTrace}", ex.Message, ex.StackTrace);
+                    }
                     break;
             }
         }
 
-        _logger.LogInformation($"There are {add} Additions. There are {upd} Updates. There are {del} Deletions. There are {err} Errors.");
+        _logger.LogInformation("There are {add} Additions. There are {upd} Updates. There are {del} Deletions. There are {err} Errors.", add, upd, del, err);
 
         if (err > 0)
         {

--- a/tests/CaasIntegrationTests/processCaasFileTest/processCaasFileTests.cs
+++ b/tests/CaasIntegrationTests/processCaasFileTest/processCaasFileTests.cs
@@ -6,175 +6,237 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using processCaasFile;
 using Microsoft.Azure.Functions.Worker.Http;
 using Common;
 using Model;
 using NHS.CohortManager.Tests.TestUtils;
+using NHS.CohortManager.CaasIntegrationService;
 
 [TestClass]
-public class processCaasFileTests
+public class ProcessCaasFileTests
 {
-    private readonly Mock<ILogger<ProcessCaasFileFunction>> loggerMock = new();
-    private readonly Mock<ICallFunction> _callFunctionMock = new();
+    private readonly Mock<ILogger<ProcessCaasFileFunction>> _logger = new();
+    private readonly Mock<ICallFunction> _callFunction = new();
     private Mock<HttpRequestData> _request;
     private readonly Mock<ICreateResponse> _createResponse = new();
     private readonly Mock<ICheckDemographic> _checkDemographic = new();
-    private readonly SetupRequest setupRequest = new();
+    private readonly SetupRequest _setupRequest = new();
     private readonly Mock<ICreateBasicParticipantData> _createBasicParticipantData = new();
 
-    public processCaasFileTests()
+    public ProcessCaasFileTests()
     {
         Environment.SetEnvironmentVariable("PMSAddParticipant", "PMSAddParticipant");
         Environment.SetEnvironmentVariable("PMSRemoveParticipant", "PMSRemoveParticipant");
         Environment.SetEnvironmentVariable("PMSUpdateParticipant", "PMSUpdateParticipant");
+        Environment.SetEnvironmentVariable("StaticValidationURL", "StaticValidationURL");
     }
 
     [TestMethod]
-    public async Task Run_Should_Log_RecordsReceived_And_Call_AddParticipant()
+    public async Task Run_Should_Call_AddParticipant_For_Each_New_Participant()
     {
         // Arrange
         var cohort = new Cohort
         {
             Participants = new List<Participant>
-                {
-                    new Participant { RecordType = Actions.New },
-                    new Participant { RecordType = Actions.New }
-                }
+            {
+                new() { RecordType = Actions.New },
+                new() { RecordType = Actions.New },
+            }
         };
         var json = JsonSerializer.Serialize(cohort);
+        _request = _setupRequest.Setup(json);
 
-        _request = setupRequest.Setup(json);
-        var sut = new ProcessCaasFileFunction(loggerMock.Object, _callFunctionMock.Object, _createResponse.Object, _checkDemographic.Object, _createBasicParticipantData.Object);
+        var sut = new ProcessCaasFileFunction(_logger.Object, _callFunction.Object, _createResponse.Object, _checkDemographic.Object, _createBasicParticipantData.Object);
 
         // Act
         var result = await sut.Run(_request.Object);
 
         // Assert
-        _callFunctionMock.Verify(
+        _callFunction.Verify(
             x => x.SendPost(It.Is<string>(s => s.Contains("PMSAddParticipant")), It.IsAny<string>()),
             Times.Exactly(2));
+        _callFunction.VerifyNoOtherCalls();
     }
 
     [TestMethod]
-    public async Task Run_Should_Log_RecordsReceived_And_Call_UpdateParticipant()
+    public async Task Run_Should_Call_UpdateParticipant_For_Each_Amended_Participant()
     {
         // Arrange
         var cohort = new Cohort
         {
             Participants = new List<Participant>
-                {
-                    new Participant { RecordType = Actions.Amended },
-                    new Participant { RecordType = Actions.Amended }
-                }
+            {
+                new() { RecordType = Actions.Amended },
+                new() { RecordType = Actions.Amended }
+            }
         };
         var json = JsonSerializer.Serialize(cohort);
-        var sut = new ProcessCaasFileFunction(loggerMock.Object, _callFunctionMock.Object, _createResponse.Object, _checkDemographic.Object, _createBasicParticipantData.Object);
+        _request = _setupRequest.Setup(json);
 
-        _request = setupRequest.Setup(json);
+        var sut = new ProcessCaasFileFunction(_logger.Object, _callFunction.Object, _createResponse.Object, _checkDemographic.Object, _createBasicParticipantData.Object);
 
         // Act
         var result = await sut.Run(_request.Object);
 
         // Assert
-        _callFunctionMock.Verify(
+        _callFunction.Verify(
             x => x.SendPost(It.Is<string>(s => s.Contains("PMSUpdateParticipant")), It.IsAny<string>()),
             Times.Exactly(2));
+        _callFunction.VerifyNoOtherCalls();
     }
 
     [TestMethod]
-    public async Task Run_Should_Log_RecordsReceived_And_UpdateParticipant_throwsException()
+    public async Task Run_Should_Call_RemoveParticipant_For_Each_Removed_Participant()
     {
         // Arrange
         var cohort = new Cohort
         {
             Participants = new List<Participant>
-                {
-                    new() { RecordType = Actions.Amended }
-                }
-        };
-        var exception = new Exception("Unable to call function");
-        var json = JsonSerializer.Serialize(cohort);
-        _request = setupRequest.Setup(json);
-
-
-        _callFunctionMock.Setup(call => call.SendPost(It.Is<string>(s => s.Contains("PMSUpdateParticipant")), It.IsAny<string>()))
-            .ThrowsAsync(exception);
-
-        var sut = new ProcessCaasFileFunction(loggerMock.Object, _callFunctionMock.Object, _createResponse.Object, _checkDemographic.Object, _createBasicParticipantData.Object);
-
-        // Act
-        await sut.Run(_request.Object);
-
-        // Assert
-        loggerMock.Verify(log =>
-            log.Log(
-            LogLevel.Information,
-            0,
-            It.Is<It.IsAnyType>((state, type) => state.ToString().Contains("Unable to call function")),
-            null,
-            (Func<object, Exception, string>)It.IsAny<object>()
-            ));
-    }
-
-    [TestMethod]
-    public async Task Run_Should_Log_RecordsReceived_And_Call_DelParticipant()
-    {
-        // Arrange
-        var cohort = new Cohort
-        {
-            Participants = new List<Participant>
-                {
-                    new Participant { RecordType = Actions.Removed },
-                    new Participant { RecordType = Actions.Removed }
-                }
+            {
+                new() { RecordType = Actions.Removed },
+                new() { RecordType = Actions.Removed }
+            }
         };
         var json = JsonSerializer.Serialize(cohort);
-        var sut = new ProcessCaasFileFunction(loggerMock.Object, _callFunctionMock.Object, _createResponse.Object, _checkDemographic.Object, _createBasicParticipantData.Object);
 
-        _request = setupRequest.Setup(json);
+        _request = _setupRequest.Setup(json);
+
+        var sut = new ProcessCaasFileFunction(_logger.Object, _callFunction.Object, _createResponse.Object, _checkDemographic.Object, _createBasicParticipantData.Object);
 
         // Act
         var result = await sut.Run(_request.Object);
 
         // Assert
-        _callFunctionMock.Verify(
+        _callFunction.Verify(
             x => x.SendPost(It.Is<string>(s => s.Contains("PMSRemoveParticipant")), It.IsAny<string>()),
             Times.Exactly(2));
+        _callFunction.VerifyNoOtherCalls();
     }
 
     [TestMethod]
-    public async Task Run_Should_Log_RecordsReceived_And_DelParticipant_throwsException()
+    public async Task Run_Should_Call_StaticValidation_For_Each_Unknown_Participant_RecordType()
     {
         // Arrange
         var cohort = new Cohort
         {
             Participants = new List<Participant>
-                {
-                    new Participant { RecordType = Actions.Removed }
-                }
+            {
+                new() { RecordType = null },
+                new() { RecordType = "Unknown" }
+            }
         };
-        var exception = new Exception("Unable to call function");
         var json = JsonSerializer.Serialize(cohort);
-        _request = setupRequest.Setup(json);
 
+        _request = _setupRequest.Setup(json);
 
-        _callFunctionMock.Setup(call => call.SendPost(It.Is<string>(s => s.Contains("PMSRemoveParticipant")), It.IsAny<string>()))
-            .ThrowsAsync(exception);
+        var sut = new ProcessCaasFileFunction(_logger.Object, _callFunction.Object, _createResponse.Object, _checkDemographic.Object, _createBasicParticipantData.Object);
 
-        var sut = new ProcessCaasFileFunction(loggerMock.Object, _callFunctionMock.Object, _createResponse.Object, _checkDemographic.Object, _createBasicParticipantData.Object);
+        // Act
+        var result = await sut.Run(_request.Object);
+
+        // Assert
+        _callFunction.Verify(
+            x => x.SendPost(It.Is<string>(s => s.Contains("StaticValidationURL")), It.IsAny<string>()),
+            Times.Exactly(2));
+        _callFunction.VerifyNoOtherCalls();
+    }
+
+    [TestMethod]
+    public async Task Run_Should_Log_Error_When_AddParticipant_Fails()
+    {
+        // Arrange
+        var cohort = new Cohort
+        {
+            Participants = new List<Participant>
+            {
+                new() { RecordType = Actions.New }
+            }
+        };
+        var json = JsonSerializer.Serialize(cohort);
+        _request = _setupRequest.Setup(json);
+
+        _callFunction.Setup(call => call.SendPost(It.Is<string>(s => s.Contains("PMSAddParticipant")), It.IsAny<string>()))
+            .ThrowsAsync(new Exception());
+
+        var sut = new ProcessCaasFileFunction(_logger.Object, _callFunction.Object, _createResponse.Object, _checkDemographic.Object, _createBasicParticipantData.Object);
 
         // Act
         await sut.Run(_request.Object);
 
         // Assert
-        loggerMock.Verify(log =>
+        _logger.Verify(log =>
             log.Log(
-            LogLevel.Information,
+            LogLevel.Error,
             0,
-            It.Is<It.IsAnyType>((state, type) => state.ToString().Contains("Unable to call function")),
+            It.Is<It.IsAnyType>((state, type) => state.ToString().Contains("Add participant function failed.")),
             null,
             (Func<object, Exception, string>)It.IsAny<object>()
-            ));
+            ), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Run_Should_Log_Error_When_UpdateParticipant_Fails()
+    {
+        // Arrange
+        var cohort = new Cohort
+        {
+            Participants = new List<Participant>
+            {
+                new() { RecordType = Actions.Amended }
+            }
+        };
+        var json = JsonSerializer.Serialize(cohort);
+        _request = _setupRequest.Setup(json);
+
+        _callFunction.Setup(call => call.SendPost(It.Is<string>(s => s.Contains("PMSUpdateParticipant")), It.IsAny<string>()))
+            .ThrowsAsync(new Exception());
+
+        var sut = new ProcessCaasFileFunction(_logger.Object, _callFunction.Object, _createResponse.Object, _checkDemographic.Object, _createBasicParticipantData.Object);
+
+        // Act
+        await sut.Run(_request.Object);
+
+        // Assert
+        _logger.Verify(log =>
+            log.Log(
+            LogLevel.Error,
+            0,
+            It.Is<It.IsAnyType>((state, type) => state.ToString().Contains("Update participant function failed.")),
+            null,
+            (Func<object, Exception, string>)It.IsAny<object>()
+            ), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Run_Should_Log_Error_When_RemoveParticipant_Fails()
+    {
+        // Arrange
+        var cohort = new Cohort
+        {
+            Participants = new List<Participant>
+            {
+                new() { RecordType = Actions.Removed }
+            }
+        };
+        var json = JsonSerializer.Serialize(cohort);
+        _request = _setupRequest.Setup(json);
+
+        _callFunction.Setup(call => call.SendPost(It.Is<string>(s => s.Contains("PMSRemoveParticipant")), It.IsAny<string>()))
+            .ThrowsAsync(new Exception());
+
+        var sut = new ProcessCaasFileFunction(_logger.Object, _callFunction.Object, _createResponse.Object, _checkDemographic.Object, _createBasicParticipantData.Object);
+
+        // Act
+        await sut.Run(_request.Object);
+
+        // Assert
+        _logger.Verify(log =>
+            log.Log(
+            LogLevel.Error,
+            0,
+            It.Is<It.IsAnyType>((state, type) => state.ToString().Contains("Remove participant function failed.")),
+            null,
+            (Func<object, Exception, string>)It.IsAny<object>()
+            ), Times.Once);
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

When processing a caas file, any participants with unknown record types will be sent to the static validation function.

## Context

<!-- Why is this change required? What problem does it solve? -->

[DTOS-3006](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-3006)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
